### PR TITLE
implement login limiter

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Mapped, mapped_column, validates
 from sqlalchemy.types import String
+from sqlalchemy import DateTime
 from app.database import db
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -10,6 +11,8 @@ class UserModel(db.Model):
     email: Mapped[str] = mapped_column(unique=True, nullable=False)
     _password: Mapped[str] = mapped_column("password", String, nullable=False)
     isOnline: Mapped[bool] = mapped_column(default=False)
+    failed_logins: Mapped[int] = mapped_column(default=0)
+    can_login_after: Mapped[datetime] = mapped_column(DateTime, nullable=True)
 
     def __init__(self, **kwargs):
         required_fields = ["username", "email"]

--- a/app/database/userWrapper.py
+++ b/app/database/userWrapper.py
@@ -65,11 +65,13 @@ class UserDatabase:
     
     def increaseFailedLoginAttemps(user):
         user.failed_logins += 1
+        db.session.commit()
 
     
     def setTimeout(user):
         user.can_login_after = datetime.now() + timedelta(minutes=3)
         user.failed_logins = 0
+        db.session.commit()
     
 
     def resetTimeout(user):

--- a/app/database/userWrapper.py
+++ b/app/database/userWrapper.py
@@ -1,5 +1,6 @@
 from app.database.models import UserModel
 from app.database import db
+from datetime import timedelta, datetime
 
 class UserDatabase:
 
@@ -45,3 +46,18 @@ class UserDatabase:
     def fetch():
         users = db.session.query(UserModel).all()
         return users
+    
+    
+    def increaseFailedLoginAttemps(user):
+        user.failed_logins += 1
+
+    
+    def setTimeout(user):
+        user.can_login_after = datetime.now() + timedelta(minutes=3)
+        user.failed_logins = 0
+    
+
+    def resetTimeout(user):
+        user.can_login_after = None
+        user.failed_logins = 0
+        db.session.commit()

--- a/app/util.py
+++ b/app/util.py
@@ -252,8 +252,9 @@ if user.can_login_after and datetime.now() < user.can_login_after:
             if not user.password_matches(loginData.get("password")):
                 UserDatabase.increaseFailedLoginAttemps(user)
 
-                if user.failed_logins >= 3:
-                    UserDatabase.setTimeout(user)
+if user.failed_logins >= 3:
+    UserDatabase.setTimeout(user)
+    return errorResponse("You entered your last password, say goodbye 🔫", 403)
 
                 return errorResponse("Go touch grass. You can't see the keyboard.")
             

--- a/app/util.py
+++ b/app/util.py
@@ -245,8 +245,9 @@ class Middleware:
             user = UserDatabase.get_user_by_username(loginData.get("username"))
             if (not user): return errorResponse("Wait a minute, who are you?")
 
-            if user.can_login_after and datetime.now() < user.can_login_after:
-                return errorResponse("You entered your last password, say goodbye 🔫", 403)
+if user.can_login_after and datetime.now() < user.can_login_after:
+    nextPossibleTime = str(user.can_login_after.strftime("%m/%d/%Y, %H:%M:%S"))
+    return errorResponse("You.. shall not.. pass! (until: " + nextPossibleTime + ")", 403)
             
             if not user.password_matches(loginData.get("password")):
                 UserDatabase.increaseFailedLoginAttemps(user)

--- a/app/util.py
+++ b/app/util.py
@@ -245,17 +245,16 @@ class Middleware:
             user = UserDatabase.get_user_by_username(loginData.get("username"))
             if (not user): return errorResponse("Wait a minute, who are you?")
 
-if user.can_login_after and datetime.now() < user.can_login_after:
-    nextPossibleTime = str(user.can_login_after.strftime("%m/%d/%Y, %H:%M:%S"))
-    return errorResponse("You.. shall not.. pass! (until: " + nextPossibleTime + ")", 403)
+            if user.can_login_after and datetime.now() < user.can_login_after:
+                nextPossibleTime = str(user.can_login_after.strftime("%m/%d/%Y, %H:%M:%S"))
+                return errorResponse("You.. shall not.. pass! (until: " + nextPossibleTime + ")", 403)
             
             if not user.password_matches(loginData.get("password")):
                 UserDatabase.increaseFailedLoginAttemps(user)
 
-if user.failed_logins >= 3:
-    UserDatabase.setTimeout(user)
-    return errorResponse("You entered your last password, say goodbye 🔫", 403)
-
+                if user.failed_logins >= 3:
+                    UserDatabase.setTimeout(user)
+                    return errorResponse("You entered your last password, say goodbye 🔫", 403)
                 return errorResponse("Go touch grass. You can't see the keyboard.")
             
             UserDatabase.resetTimeout(user)

--- a/app/util.py
+++ b/app/util.py
@@ -243,10 +243,10 @@ class Middleware:
             if "password" not in loginData: return errorResponse("Password missing")
 
             user = UserDatabase.get_user_by_username(loginData.get("username"))
-            if (not user): return errorResponse("Wrong username or password")
+            if (not user): return errorResponse("Wait a minute, who are you?")
 
             if user.can_login_after and datetime.now() < user.can_login_after:
-                return errorResponse("you entered your last password, say goodbye 🔫", 403)
+                return errorResponse("You entered your last password, say goodbye 🔫", 403)
             
             if not user.password_matches(loginData.get("password")):
                 UserDatabase.increaseFailedLoginAttemps(user)
@@ -254,8 +254,7 @@ class Middleware:
                 if user.failed_logins >= 3:
                     UserDatabase.setTimeout(user)
 
-                db.session.commit()
-                return errorResponse("Wrong username or password")
+                return errorResponse("Go touch grass. You can't see the keyboard.")
             
             UserDatabase.resetTimeout(user)
                


### PR DESCRIPTION
Fixes #34
- added ```failed_logins``` and ```can_login_after``` to ```models.py```
- added logic for login limiter to 3 tries otherwise lock out for 3 minutes. If login correct afterwards, everything is reset.

Tested and works but please try on your end.

- When entering wrong password (previous version remains unchanged, this was just tested to make sure nothing changed from previous implementation)
![image](https://github.com/user-attachments/assets/326a0f09-8e24-44e0-be78-3b2d5ba4e86f)

- When user enters wrong password 3 times
![image](https://github.com/user-attachments/assets/5d5df66b-dfa6-4acf-ac9e-bb066399ab6a)

- Shows time when user can enter their password again, otherwise message above will keep displaying
![image](https://github.com/user-attachments/assets/82fc5328-5bb7-47d9-8ab5-60a9c5e47be9)

- When user enters wrong password, it will be stored in "failed_logins"
![image](https://github.com/user-attachments/assets/0f839c74-4031-4893-b923-f99735c32265)
